### PR TITLE
Bug Fix - Retrieving Result Causes a Deadlock

### DIFF
--- a/VVRestApi/VVRestApiNET45/Vault/VaultApi.cs
+++ b/VVRestApi/VVRestApiNET45/Vault/VaultApi.cs
@@ -38,7 +38,7 @@ namespace VVRestApi.Vault
         /// </summary>
         public VaultApi(ClientSecrets clientSecrets)
         {
-            this.ApiTokens = HttpHelper.GetAccessToken(clientSecrets.OAuthTokenEndPoint, clientSecrets.ApiKey, clientSecrets.ApiSecret).Result;
+            Task.Run(() => this.ApiTokens = HttpHelper.GetAccessToken(clientSecrets.OAuthTokenEndPoint, clientSecrets.ApiKey, clientSecrets.ApiSecret).Result).Wait();
 
             if (!string.IsNullOrEmpty(this.ApiTokens.AccessToken))
             {
@@ -112,7 +112,7 @@ namespace VVRestApi.Vault
         /// <param name="password"></param>
         public VaultApi(ClientSecrets clientSecrets, string userName, string password)
         {
-            this.ApiTokens = HttpHelper.GetAccessToken(clientSecrets.OAuthTokenEndPoint, clientSecrets.ApiKey, clientSecrets.ApiSecret, userName, password).Result;
+            Task.Run(() => this.ApiTokens = HttpHelper.GetAccessToken(clientSecrets.OAuthTokenEndPoint, clientSecrets.ApiKey, clientSecrets.ApiSecret, userName, password).Result).Wait();
 
             if (!string.IsNullOrEmpty(this.ApiTokens.AccessToken))
             {


### PR DESCRIPTION
I was able to retrieve the Token when running in a console application, but I had to make the change above to get it to work with a web application. This is due to web applications and Web APIs using contexts. A console application doesn't use contexts; hence, why it worked in unit testing. The following two links go into more detail about this issue...

http://stackoverflow.com/questions/34078296/httpclient-postasync-never-return-response

http://blog.stephencleary.com/2012/07/dont-block-on-async-code.html